### PR TITLE
add exceptions to __init__

### DIFF
--- a/apiclient/__init__.py
+++ b/apiclient/__init__.py
@@ -17,3 +17,12 @@ from apiclient.response_handlers import (
     YamlResponseHandler,
 )
 from apiclient.retrying import retry_request
+from apiclient.exceptions import {
+    APIClientError,
+    ResponseParseError,
+    APIRequestError,
+    RedirectionError,
+    ClientError,
+    ServerError,
+    UnexpectedError,
+}


### PR DESCRIPTION
> Problem:
When I want to catch explicit an APIclient exception,
it's not possible. Because I cannot import them into my project.

> Solution:
Adding the exceptions to __init__.py

> Note: